### PR TITLE
Add basic file upload feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "report": "rimraf dist && vite build",
     "preview": "vite preview",
     "preview:build": "pnpm build && vite preview",
+    "upload:server": "ts-node server/uploadServer.ts",
     "typecheck": "tsc --noEmit && vue-tsc --noEmit --skipLibCheck",
     "svgo": "svgo -f . -r",
     "clean:cache": "rimraf .eslintcache && rimraf pnpm-lock.yaml && rimraf node_modules && pnpm store prune && pnpm install",
@@ -71,7 +72,9 @@
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",
     "vue-tippy": "^6.7.0",
-    "vue-types": "^6.0.0"
+    "vue-types": "^6.0.0",
+    "express": "^4.18.4",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.0",
@@ -90,6 +93,9 @@
     "@types/sortablejs": "^1.15.8",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vitejs/plugin-vue-jsx": "^4.1.2",
+    "@types/express": "^4.17.21",
+    "@types/multer": "^1.4.7",
+    "ts-node": "^10.9.1",
     "boxen": "^8.0.1",
     "code-inspector-plugin": "^0.20.10",
     "cssnano": "^7.0.6",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "outDir": "dist"
+  },
+  "include": ["./**/*.ts"]
+}

--- a/server/uploadServer.ts
+++ b/server/uploadServer.ts
@@ -1,0 +1,23 @@
+import express from "express";
+import multer from "multer";
+import path from "path";
+import fs from "fs";
+
+const app = express();
+const upload = multer({ dest: path.resolve("uploads") });
+
+app.post("/upload", upload.single("file"), (req, res) => {
+  const file = req.file;
+  if (!file) {
+    return res.status(400).json({ success: false });
+  }
+  if (!fs.existsSync("uploads")) {
+    fs.mkdirSync("uploads", { recursive: true });
+  }
+  res.json({ success: true, url: `/uploads/${file.filename}` });
+});
+
+const port = Number(process.env.PORT) || 3001;
+app.listen(port, () => {
+  console.log(`upload server running at http://localhost:${port}`);
+});

--- a/src/api/upload.ts
+++ b/src/api/upload.ts
@@ -1,0 +1,13 @@
+import { http } from "@/utils/http";
+
+export interface UploadResult {
+  success: boolean;
+  url?: string;
+}
+
+export const uploadFile = (data: FormData) => {
+  return http.request<UploadResult>("post", "/upload", {
+    headers: { "Content-Type": "multipart/form-data" },
+    data
+  });
+};

--- a/src/router/modules/upload.ts
+++ b/src/router/modules/upload.ts
@@ -1,0 +1,23 @@
+const Layout = () => import("@/layout/index.vue");
+
+export default {
+  path: "/upload",
+  name: "Upload",
+  component: Layout,
+  redirect: "/upload/index",
+  meta: {
+    icon: "ep/upload",
+    title: "文件上传",
+    rank: 11
+  },
+  children: [
+    {
+      path: "/upload/index",
+      name: "UploadDemo",
+      component: () => import("@/views/upload/index.vue"),
+      meta: {
+        title: "上传文件"
+      }
+    }
+  ]
+} satisfies RouteConfigsTable;

--- a/src/views/upload/index.vue
+++ b/src/views/upload/index.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { uploadFile } from "@/api/upload";
+import { message } from "@/utils/message";
+
+defineOptions({ name: "UploadDemo" });
+
+function handleUpload(options: any) {
+  const formData = new FormData();
+  formData.append("file", options.file);
+  uploadFile(formData)
+    .then(() => {
+      message("上传成功", { type: "success" });
+      options.onSuccess && options.onSuccess(null);
+    })
+    .catch(() => {
+      message("上传失败", { type: "error" });
+      options.onError && options.onError(new Error("upload error"));
+    });
+}
+</script>
+
+<template>
+  <el-upload :http-request="handleUpload" list-type="text">
+    <el-button type="primary">上传文件</el-button>
+  </el-upload>
+</template>


### PR DESCRIPTION
## Summary
- add an Express upload server written in TypeScript
- expose `uploadFile` API helper
- create simple upload page and router entry
- include script and deps for the server

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm typecheck` *(fails: Cannot find type definition file for '@pureadmin/descriptions/volar')*

------
https://chatgpt.com/codex/tasks/task_e_68411ac753588322855d56d50119fce6